### PR TITLE
Crafting

### DIFF
--- a/Scripts/Engines/Craft/Core/CraftSystem.cs
+++ b/Scripts/Engines/Craft/Core/CraftSystem.cs
@@ -136,8 +136,16 @@ namespace Server.Engines.Craft
 			{
 				// The item is in the list, try to create it
 				// Test code: items like sextant parts can be crafted either directly from ingots, or from different parts
-				realCraftItem.Craft( from, this, typeRes, typeRes2, tool );
-				//craftItem.Craft( from, this, typeRes, tool );
+                //Check if resourceType 2 is used.
+                if (typeRes2 == null)
+                {
+                    craftItem.Craft(from, this, typeRes, tool);
+                }
+                else
+                {
+                    realCraftItem.Craft(from, this, typeRes, typeRes2, tool);
+                }
+				
 			}
 		}
 

--- a/Scripts/Engines/Craft/Core/QueryMakersMarkGump.cs
+++ b/Scripts/Engines/Craft/Core/QueryMakersMarkGump.cs
@@ -41,7 +41,32 @@ namespace Server.Engines.Craft
 			AddButton( 20, 125, 4005, 4007, 0, GumpButtonType.Reply, 0 );
 		}
 
-		public override void OnResponse( Server.Network.NetState sender, RelayInfo info )
+        public QueryMakersMarkGump(int quality, Mobile from, CraftItem craftItem, CraftSystem craftSystem, Type typeRes, BaseTool tool) : base(100, 200)
+        {
+            from.CloseGump(typeof(QueryMakersMarkGump));
+
+            m_Quality = quality;
+            m_From = from;
+            m_CraftItem = craftItem;
+            m_CraftSystem = craftSystem;
+            m_TypeRes = typeRes;
+            m_Tool = tool;
+
+            AddPage(0);
+
+            AddBackground(0, 0, 220, 170, 5054);
+            AddBackground(10, 10, 200, 150, 3000);
+
+            AddHtmlLocalized(20, 20, 180, 80, 1018317, false, false); // Do you wish to place your maker's mark on this item?
+
+            AddHtmlLocalized(55, 100, 140, 25, 1011011, false, false); // CONTINUE
+            AddButton(20, 100, 4005, 4007, 1, GumpButtonType.Reply, 0);
+
+            AddHtmlLocalized(55, 125, 140, 25, 1011012, false, false); // CANCEL
+            AddButton(20, 125, 4005, 4007, 0, GumpButtonType.Reply, 0);
+        }
+
+        public override void OnResponse( Server.Network.NetState sender, RelayInfo info )
 		{
 			bool makersMark = ( info.ButtonID == 1 );
 

--- a/Scripts/Engines/Factions/Items/Traps/BaseFactionTrapDeed.cs
+++ b/Scripts/Engines/Factions/Items/Traps/BaseFactionTrapDeed.cs
@@ -107,6 +107,14 @@ namespace Server.Factions
 			return 1;
 		}
 
-		#endregion
-	}
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            ItemID = 0x14F0;
+            Faction = Faction.Find(from);
+
+            return 1;
+        }
+
+        #endregion
+    }
 }

--- a/Scripts/Items/Addons/BaseAddonContainerDeed.cs
+++ b/Scripts/Items/Addons/BaseAddonContainerDeed.cs
@@ -100,9 +100,26 @@ namespace Server.Items
 
 			return quality;
 		}
-		#endregion
 
-		private class InternalTarget : Target
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            Type resourceType = typeRes;
+
+            if (resourceType == null)
+                resourceType = craftItem.Resources.GetAt(0).ItemType;
+
+            Resource = CraftResources.GetFromType(resourceType);
+
+            CraftContext context = craftSystem.GetContext(from);
+
+            if (context != null && context.DoNotColor)
+                Hue = 0;
+
+            return quality;
+        }
+        #endregion
+
+        private class InternalTarget : Target
 		{
 			private BaseAddonContainerDeed m_Deed;
 

--- a/Scripts/Items/Armor/BaseArmor.cs
+++ b/Scripts/Items/Armor/BaseArmor.cs
@@ -1651,6 +1651,58 @@ namespace Server.Items
 			return quality;
 		}
 
-		#endregion
-	}
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            // TODO: Adapt to use typeRes2
+            Quality = (ArmorQuality)quality;
+
+            if (makersMark)
+                Crafter = from;
+
+            Type resourceType = typeRes;
+
+            if (resourceType == null)
+                resourceType = craftItem.Resources.GetAt(0).ItemType;
+
+            Resource = CraftResources.GetFromType(resourceType);
+            PlayerConstructed = true;
+
+            CraftContext context = craftSystem.GetContext(from);
+
+            if (context != null && context.DoNotColor)
+                Hue = 0;
+
+            if (Quality == ArmorQuality.Exceptional)
+            {
+                if (!(Core.ML && this is BaseShield))       // Guessed Core.ML removed exceptional resist bonuses from crafted shields
+                    DistributeBonuses((tool is BaseRunicTool ? 6 : Core.SE ? 15 : 14)); // Not sure since when, but right now 15 points are added, not 14.
+
+                if (Core.ML && !(this is BaseShield))
+                {
+                    int bonus = (int)(from.Skills.ArmsLore.Value / 20);
+
+                    for (int i = 0; i < bonus; i++)
+                    {
+                        switch (Utility.Random(5))
+                        {
+                            case 0: m_PhysicalBonus++; break;
+                            case 1: m_FireBonus++; break;
+                            case 2: m_ColdBonus++; break;
+                            case 3: m_EnergyBonus++; break;
+                            case 4: m_PoisonBonus++; break;
+                        }
+                    }
+
+                    from.CheckSkill(SkillName.ArmsLore, 0, 100);
+                }
+            }
+
+            if (Core.AOS && tool is BaseRunicTool)
+                ((BaseRunicTool)tool).ApplyAttributesTo(this);
+
+            return quality;
+        }
+
+        #endregion
+    }
 }

--- a/Scripts/Items/Clothing/BaseClothing.cs
+++ b/Scripts/Items/Clothing/BaseClothing.cs
@@ -1036,6 +1036,38 @@ namespace Server.Items
 			return quality;
 		}
 
-		#endregion
-	}
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            // TODO: Adapt to use typeRes2
+            Quality = (ClothingQuality)quality;
+
+            if (makersMark)
+                Crafter = from;
+
+            if (DefaultResource != CraftResource.None)
+            {
+                Type resourceType = typeRes;
+
+                if (resourceType == null)
+                    resourceType = craftItem.Resources.GetAt(0).ItemType;
+
+                Resource = CraftResources.GetFromType(resourceType);
+            }
+            else
+            {
+                Hue = resHue;
+            }
+
+            PlayerConstructed = true;
+
+            CraftContext context = craftSystem.GetContext(from);
+
+            if (context != null && context.DoNotColor)
+                Hue = 0;
+
+            return quality;
+        }
+
+        #endregion
+    }
 }

--- a/Scripts/Items/Containers/LockableContainer.cs
+++ b/Scripts/Items/Containers/LockableContainer.cs
@@ -396,11 +396,49 @@ namespace Server.Items
 			return 1;
 		}
 
-		#endregion
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            // TODO: Adapt to use typeRes2
+            if (from.CheckSkill(SkillName.Tinkering, -5.0, 15.0))
+            {
+                from.SendLocalizedMessage(500636); // Your tinker skill was sufficient to make the item lockable.
 
-		#region IShipwreckedItem Members
+                Key key = new Key(KeyType.Copper, Key.RandomValue());
 
-		private bool m_IsShipwreckedItem;
+                KeyValue = key.KeyValue;
+                DropItem(key);
+
+                double tinkering = from.Skills[SkillName.Tinkering].Value;
+                int level = (int)(tinkering * 0.8);
+
+                RequiredSkill = level - 4;
+                LockLevel = level - 14;
+                MaxLockLevel = level + 35;
+
+                if (LockLevel == 0)
+                    LockLevel = -1;
+                else if (LockLevel > 95)
+                    LockLevel = 95;
+
+                if (RequiredSkill > 95)
+                    RequiredSkill = 95;
+
+                if (MaxLockLevel > 95)
+                    MaxLockLevel = 95;
+            }
+            else
+            {
+                from.SendLocalizedMessage(500637); // Your tinker skill was insufficient to make the item lockable.
+            }
+
+            return 1;
+        }
+
+        #endregion
+
+        #region IShipwreckedItem Members
+
+        private bool m_IsShipwreckedItem;
 
 		[CommandProperty( AccessLevel.GameMaster )]
 		public bool IsShipwreckedItem

--- a/Scripts/Items/Deeds/DragonBardingDeed.cs
+++ b/Scripts/Items/Deeds/DragonBardingDeed.cs
@@ -145,6 +145,28 @@ namespace Server.Items
 			return quality;
 		}
 
-		#endregion
-	}
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            Exceptional = (quality >= 2);
+
+            if (makersMark)
+                Crafter = from;
+
+            Type resourceType = typeRes;
+
+            if (resourceType == null)
+                resourceType = craftItem.Resources.GetAt(0).ItemType;
+
+            Resource = CraftResources.GetFromType(resourceType);
+
+            CraftContext context = craftSystem.GetContext(from);
+
+            if (context != null && context.DoNotColor)
+                Hue = 0;
+
+            return quality;
+        }
+
+        #endregion
+    }
 }

--- a/Scripts/Items/Jewels/BaseJewel.cs
+++ b/Scripts/Items/Jewels/BaseJewel.cs
@@ -415,6 +415,47 @@ namespace Server.Items
 			return 1;
 		}
 
-		#endregion
-	}
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            Type resourceType = typeRes;
+
+            if (resourceType == null)
+                resourceType = craftItem.Resources.GetAt(0).ItemType;
+
+            Resource = CraftResources.GetFromType(resourceType);
+
+            CraftContext context = craftSystem.GetContext(from);
+
+            if (context != null && context.DoNotColor)
+                Hue = 0;
+
+            if (1 < craftItem.Resources.Count)
+            {
+                resourceType = craftItem.Resources.GetAt(1).ItemType;
+
+                if (resourceType == typeof(StarSapphire))
+                    GemType = GemType.StarSapphire;
+                else if (resourceType == typeof(Emerald))
+                    GemType = GemType.Emerald;
+                else if (resourceType == typeof(Sapphire))
+                    GemType = GemType.Sapphire;
+                else if (resourceType == typeof(Ruby))
+                    GemType = GemType.Ruby;
+                else if (resourceType == typeof(Citrine))
+                    GemType = GemType.Citrine;
+                else if (resourceType == typeof(Amethyst))
+                    GemType = GemType.Amethyst;
+                else if (resourceType == typeof(Tourmaline))
+                    GemType = GemType.Tourmaline;
+                else if (resourceType == typeof(Amber))
+                    GemType = GemType.Amber;
+                else if (resourceType == typeof(Diamond))
+                    GemType = GemType.Diamond;
+            }
+
+            return 1;
+        }
+
+        #endregion
+    }
 }

--- a/Scripts/Items/Maps/MapItem.cs
+++ b/Scripts/Items/Maps/MapItem.cs
@@ -398,6 +398,12 @@ namespace Server.Items
 			return 1;
 		}
 
-		#endregion
-	}
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            CraftInit(from);
+            return 1;
+        }
+
+        #endregion
+    }
 }

--- a/Scripts/Items/Quivers/BaseQuiver.cs
+++ b/Scripts/Items/Quivers/BaseQuiver.cs
@@ -465,6 +465,16 @@ namespace Server.Items
 
 			return quality;
 		}
-		#endregion
-	}
+
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            Quality = (ClothingQuality)quality;
+
+            if (makersMark)
+                Crafter = from;
+
+            return quality;
+        }
+        #endregion
+    }
 }

--- a/Scripts/Items/Skill Items/Harvest Tools/BaseHarvestTool.cs
+++ b/Scripts/Items/Skill Items/Harvest Tools/BaseHarvestTool.cs
@@ -237,6 +237,16 @@ namespace Server.Items
 			return quality;
 		}
 
-		#endregion
-	}
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            Quality = (ToolQuality)quality;
+
+            if (makersMark)
+                Crafter = from;
+
+            return quality;
+        }
+
+        #endregion
+    }
 }

--- a/Scripts/Items/Skill Items/Magical/Potions/BasePotion.cs
+++ b/Scripts/Items/Skill Items/Magical/Potions/BasePotion.cs
@@ -270,6 +270,45 @@ namespace Server.Items
 			return 1;
 		}
 
-		#endregion
-	}
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            if (craftSystem is DefAlchemy)
+            {
+                Container pack = from.Backpack;
+
+                if (pack != null)
+                {
+                    if ((int)PotionEffect >= (int)PotionEffect.Invisibility)
+                        return 1;
+
+                    List<PotionKeg> kegs = pack.FindItemsByType<PotionKeg>();
+
+                    for (int i = 0; i < kegs.Count; ++i)
+                    {
+                        PotionKeg keg = kegs[i];
+
+                        if (keg == null)
+                            continue;
+
+                        if (keg.Held <= 0 || keg.Held >= 100)
+                            continue;
+
+                        if (keg.Type != PotionEffect)
+                            continue;
+
+                        ++keg.Held;
+
+                        Consume();
+                        from.AddToBackpack(new Bottle());
+
+                        return -1; // signal placed in keg
+                    }
+                }
+            }
+
+            return 1;
+        }
+
+        #endregion
+    }
 }

--- a/Scripts/Items/Skill Items/Magical/Runebook.cs
+++ b/Scripts/Items/Skill Items/Magical/Runebook.cs
@@ -477,8 +477,25 @@ namespace Server.Items
 			return quality;
 		}
 
-		#endregion
-	}
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            int charges = 5 + quality + (int)(from.Skills[SkillName.Inscribe].Value / 30);
+
+            if (charges > 10)
+                charges = 10;
+
+            MaxCharges = (Core.SE ? charges * 2 : charges);
+
+            if (makersMark)
+                Crafter = from;
+
+            m_Quality = (BookQuality)(quality - 1);
+
+            return quality;
+        }
+
+        #endregion
+    }
 
 	public class RunebookEntry
 	{

--- a/Scripts/Items/Skill Items/Magical/Spellbook.cs
+++ b/Scripts/Items/Skill Items/Magical/Spellbook.cs
@@ -909,5 +909,53 @@ namespace Server.Items
 
 			return quality;
 		}
-	}
+
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            int magery = from.Skills.Magery.BaseFixedPoint;
+
+            if (magery >= 800)
+            {
+                int[] propertyCounts;
+                int minIntensity;
+                int maxIntensity;
+
+                if (magery >= 1000)
+                {
+                    if (magery >= 1200)
+                        propertyCounts = m_LegendPropertyCounts;
+                    else if (magery >= 1100)
+                        propertyCounts = m_ElderPropertyCounts;
+                    else
+                        propertyCounts = m_GrandPropertyCounts;
+
+                    minIntensity = 55;
+                    maxIntensity = 75;
+                }
+                else if (magery >= 900)
+                {
+                    propertyCounts = m_MasterPropertyCounts;
+                    minIntensity = 25;
+                    maxIntensity = 45;
+                }
+                else
+                {
+                    propertyCounts = m_AdeptPropertyCounts;
+                    minIntensity = 0;
+                    maxIntensity = 15;
+                }
+
+                int propertyCount = propertyCounts[Utility.Random(propertyCounts.Length)];
+
+                BaseRunicTool.ApplyAttributesTo(this, true, 0, propertyCount, minIntensity, maxIntensity);
+            }
+
+            if (makersMark)
+                Crafter = from;
+
+            m_Quality = (BookQuality)(quality - 1);
+
+            return quality;
+        }
+    }
 }

--- a/Scripts/Items/Skill Items/Musical Instruments/BaseInstrument.cs
+++ b/Scripts/Items/Skill Items/Musical Instruments/BaseInstrument.cs
@@ -582,6 +582,16 @@ namespace Server.Items
 			return quality;
 		}
 
-		#endregion
-	}
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            Quality = (InstrumentQuality)quality;
+
+            if (makersMark)
+                Crafter = from;
+
+            return quality;
+        }
+
+        #endregion
+    }
 }

--- a/Scripts/Items/Skill Items/Ninjitsu/FukiyaDarts.cs
+++ b/Scripts/Items/Skill Items/Ninjitsu/FukiyaDarts.cs
@@ -100,5 +100,13 @@ namespace Server.Items
 
 			return quality;
 		}
-	}
+
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            if (quality == 2)
+                UsesRemaining *= 2;
+
+            return quality;
+        }
+    }
 }

--- a/Scripts/Items/Skill Items/Ninjitsu/Shuriken.cs
+++ b/Scripts/Items/Skill Items/Ninjitsu/Shuriken.cs
@@ -101,5 +101,13 @@ namespace Server.Items
 
 			return quality;
 		}
-	}
+
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            if (quality == 2)
+                UsesRemaining *= 2;
+
+            return quality;
+        }
+    }
 }

--- a/Scripts/Items/Skill Items/Tools/BaseTool.cs
+++ b/Scripts/Items/Skill Items/Tools/BaseTool.cs
@@ -194,6 +194,16 @@ namespace Server.Items
 			return quality;
 		}
 
-		#endregion
-	}
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            Quality = (ToolQuality)quality;
+
+            if (makersMark)
+                Crafter = from;
+
+            return quality;
+        }
+
+        #endregion
+    }
 }

--- a/Scripts/Items/Weapons/BaseWeapon.cs
+++ b/Scripts/Items/Weapons/BaseWeapon.cs
@@ -3611,10 +3611,138 @@ namespace Server.Items
 			return quality;
 		}
 
-		#endregion
-	}
+        public int OnCraft(int quality, bool makersMark, Mobile from, CraftSystem craftSystem, Type typeRes, BaseTool tool, CraftItem craftItem, int resHue)
+        {
+            Quality = (WeaponQuality)quality;
 
-	public enum CheckSlayerResult
+            if (makersMark)
+                Crafter = from;
+
+            PlayerConstructed = true;
+
+            Type resourceType = typeRes;
+
+            if (resourceType == null)
+                resourceType = craftItem.Resources.GetAt(0).ItemType;
+
+            if (Core.AOS)
+            {
+                Resource = CraftResources.GetFromType(resourceType);
+
+                CraftContext context = craftSystem.GetContext(from);
+
+                if (context != null && context.DoNotColor)
+                    Hue = 0;
+
+                if (tool is BaseRunicTool)
+                    ((BaseRunicTool)tool).ApplyAttributesTo(this);
+
+                if (Quality == WeaponQuality.Exceptional)
+                {
+                    if (Attributes.WeaponDamage > 35)
+                        Attributes.WeaponDamage -= 20;
+                    else
+                        Attributes.WeaponDamage = 15;
+
+                    if (Core.ML)
+                    {
+                        Attributes.WeaponDamage += (int)(from.Skills.ArmsLore.Value / 20);
+
+                        if (Attributes.WeaponDamage > 50)
+                            Attributes.WeaponDamage = 50;
+
+                        from.CheckSkill(SkillName.ArmsLore, 0, 100);
+                    }
+                }
+            }
+            else if (tool is BaseRunicTool)
+            {
+                CraftResource thisResource = CraftResources.GetFromType(resourceType);
+
+                if (thisResource == ((BaseRunicTool)tool).Resource)
+                {
+                    Resource = thisResource;
+
+                    CraftContext context = craftSystem.GetContext(from);
+
+                    if (context != null && context.DoNotColor)
+                        Hue = 0;
+
+                    switch (thisResource)
+                    {
+                        case CraftResource.DullCopper:
+                            {
+                                Identified = true;
+                                DurabilityLevel = WeaponDurabilityLevel.Durable;
+                                AccuracyLevel = WeaponAccuracyLevel.Accurate;
+                                break;
+                            }
+                        case CraftResource.ShadowIron:
+                            {
+                                Identified = true;
+                                DurabilityLevel = WeaponDurabilityLevel.Durable;
+                                DamageLevel = WeaponDamageLevel.Ruin;
+                                break;
+                            }
+                        case CraftResource.Copper:
+                            {
+                                Identified = true;
+                                DurabilityLevel = WeaponDurabilityLevel.Fortified;
+                                DamageLevel = WeaponDamageLevel.Ruin;
+                                AccuracyLevel = WeaponAccuracyLevel.Surpassingly;
+                                break;
+                            }
+                        case CraftResource.Bronze:
+                            {
+                                Identified = true;
+                                DurabilityLevel = WeaponDurabilityLevel.Fortified;
+                                DamageLevel = WeaponDamageLevel.Might;
+                                AccuracyLevel = WeaponAccuracyLevel.Surpassingly;
+                                break;
+                            }
+                        case CraftResource.Gold:
+                            {
+                                Identified = true;
+                                DurabilityLevel = WeaponDurabilityLevel.Indestructible;
+                                DamageLevel = WeaponDamageLevel.Force;
+                                AccuracyLevel = WeaponAccuracyLevel.Eminently;
+                                break;
+                            }
+                        case CraftResource.Agapite:
+                            {
+                                Identified = true;
+                                DurabilityLevel = WeaponDurabilityLevel.Indestructible;
+                                DamageLevel = WeaponDamageLevel.Power;
+                                AccuracyLevel = WeaponAccuracyLevel.Eminently;
+                                break;
+                            }
+                        case CraftResource.Verite:
+                            {
+                                Identified = true;
+                                DurabilityLevel = WeaponDurabilityLevel.Indestructible;
+                                DamageLevel = WeaponDamageLevel.Power;
+                                AccuracyLevel = WeaponAccuracyLevel.Exceedingly;
+                                break;
+                            }
+                        case CraftResource.Valorite:
+                            {
+                                Identified = true;
+                                DurabilityLevel = WeaponDurabilityLevel.Indestructible;
+                                DamageLevel = WeaponDamageLevel.Vanq;
+                                AccuracyLevel = WeaponAccuracyLevel.Supremely;
+                                break;
+                            }
+                    }
+                }
+            }
+
+            return quality;
+        }
+
+        #endregion
+    }
+
+    public enum CheckSlayerResult
 	{
 		None,
 		Slayer,


### PR DESCRIPTION
Fixed crash when crafting a weapon/amor anything else.
Error was:

System.NullReferenceException: Object reference not set to an instance of an object.
   at Server.Engines.Craft.CraftItem.ConsumeRes(Mobile from, Type typeRes, Type typeRes2, CraftSystem craftSystem, Int32& resHue, Int32& maxAmount, ConsumeType consumeType, Object& message, Boolean isFailure)
   at Server.Engines.Craft.CraftItem.Craft(Mobile from, CraftSystem craftSystem, Type typeRes, Type typeRes2, BaseTool tool)
   at Server.Engines.Craft.CraftGump.CraftItem(CraftItem item)
   at Server.Network.PacketHandlers.DisplayGumpResponse(NetState state, PacketReader pvSrc) in C:\Users\Titaantje\Documents\GitHub\ThreesandUO\Server\Network\PacketHandlers.cs:line 1262
   at Server.Network.MessagePump.HandleReceive(NetState ns) in C:\Users\Titaantje\Documents\GitHub\ThreesandUO\Server\Network\MessagePump.cs:line 260
   at Server.Network.MessagePump.Slice() in C:\Users\Titaantje\Documents\GitHub\ThreesandUO\Server\Network\MessagePump.cs:line 127
   at Server.Core.Main(String[] args) in C:\Users\Titaantje\Documents\GitHub\ThreesandUO\Server\Main.cs:line 532
